### PR TITLE
Allow browser extension to be unlocked on Linux via Polkit

### DIFF
--- a/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.ts
+++ b/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.ts
@@ -269,7 +269,7 @@ export abstract class BrowserPlatformUtilsService implements PlatformUtilsServic
 
   async supportsBiometric() {
     const platformInfo = await BrowserApi.getPlatformInfo();
-    if (platformInfo.os === "mac" || platformInfo.os === "win") {
+    if (platformInfo.os === "mac" || platformInfo.os === "win" || platformInfo.os === "linux") {
       return true;
     }
     return false;


### PR DESCRIPTION
It appears that on newer versions of Bitwarden's browser extension that the "Unlock with biometrics" option has been removed for Linux.

This PR re-enables the options:

<img src="https://github.com/quexten/clients/assets/129616584/62bb2690-30d5-4116-b245-4bd3e0284de2" width="300">
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
<img src="https://github.com/quexten/clients/assets/129616584/51a4c6db-0786-44c5-b49d-d3f59844d81f" width="300">

&nbsp;
<details>
<summary>Installation instructions</summary>

1. [Build and install](https://github.com/DigitallyRefined/clients/releases/tag/desktop-v2024.4.1-unix-biometrics) the ["Unix biometrics unlock via Polkit" branch](https://github.com/bitwarden/clients/pull/4586) from source
2. Enable the "Allow browser integration" to allow biometric unlock from the browser extension
3. [Build the browser extension from source](https://contributing.bitwarden.com/getting-started/clients/browser/)
4. Sideload the browser extension by enabling developer mode
5. Note the extension ID and add it the `allowed_origins` array in `~/.config/google-chrome/NativeMessagingHosts/com.8bit.bitwarden.json` (or similar for other browsers)
</details>